### PR TITLE
cseek: reset avail_in/out for cfh->xzs (bug 708736)

### DIFF
--- a/libcfile/cfile.c
+++ b/libcfile/cfile.c
@@ -709,6 +709,7 @@ cseek(cfile *cfh, ssize_t offset, int offset_type)
 			if(lzma_stream_decoder(cfh->xzs, UINT64_MAX, LZMA_TELL_UNSUPPORTED_CHECK)!=LZMA_OK) {
 				return IO_ERROR;
 			}
+			cfh->xzs->avail_in = cfh->xzs->avail_out = 0;
 			cfh->raw.pos = cfh->raw.offset = cfh->raw.end = cfh->data.pos =
 				cfh->data.offset = cfh->data.end = 0;
 			if(ensure_lseek_position(cfh)) {


### PR DESCRIPTION
Reset avail_in/out for cfh->xzs in order to correct interaction
with the crefill function. This solves a seek error for tarsync
as reported in bug 708736.

Bug: https://bugs.gentoo.org/708736
Signed-off-by: Zac Medico <zmedico@gentoo.org>